### PR TITLE
Changed the PHP7 array definitions to a PHP 5.6 compatible version

### DIFF
--- a/external-login.php
+++ b/external-login.php
@@ -16,10 +16,12 @@ define( 'EXLOG_PATH_PLUGIN_LOGIN', EXLOG_PATH_PLUGIN_BASE . '/login');
 define( 'EXLOG_PATH_PLUGIN_OPTIONS', EXLOG_PATH_PLUGIN_BASE . '/options');
 define( 'EXLOG_PATH_PLUGIN_TOOLS', EXLOG_PATH_PLUGIN_BASE . '/tools');
 define( 'EXLOG_PATH_PLUGIN_SANITISATION_VALIDATION', EXLOG_PATH_PLUGIN_BASE . '/sanitisation_validation');
-define( 'EXLOG_PLUGIN_DATA', get_file_data(EXLOG_PLUGIN_FILE_PATH, [
+$array = get_file_data(EXLOG_PLUGIN_FILE_PATH, [
         'name' => 'Plugin Name',
         'slug' => 'Text Domain'
-    ], 'plugin'));
+    ], 'plugin');
+$plugin_data = serialize($array);
+define('EXLOG_PLUGIN_DATA', $plugin_data);
 
 
 include EXLOG_PATH_PLUGIN_OPTIONS . '/wpconfig_options.php';

--- a/options/add_plugin_options_links.php
+++ b/options/add_plugin_options_links.php
@@ -1,7 +1,8 @@
 <?php
 function exlog_plugin_action_links( $links ) {
+	$plugin_options = unserialize(EXLOG_PLUGIN_OPTIONS);
     $links = array_merge( array(
-        '<a href="' . esc_url( admin_url( '/options-general.php?page=' . EXLOG_PLUGIN_DATA['slug']) ) . '">Settings</a>'
+        '<a href="' . esc_url( admin_url( '/options-general.php?page=' . $plugin_options['slug']) ) . '">Settings</a>'
     ), $links );
     return $links;
 }

--- a/options/options_external_login.php
+++ b/options/options_external_login.php
@@ -4,9 +4,11 @@ add_action( 'admin_menu', 'exlog_create_options_menu' );
 add_action( 'admin_init', 'exlog_register_options_menu_settings');
 
 function exlog_register_options_menu_settings() {
-    foreach (EXLOG_OPTION_FIELDS as $section) {
+	$plugin_data = unserialize(EXLOG_PLUGIN_DATA);
+	$option_fields = unserialize(EXLOG_OPTION_FIELDS);
+    foreach ($option_fields as $section) {
         foreach ($section['section_fields'] as $form_field) {
-            register_setting(EXLOG_PLUGIN_DATA['slug'] . '-option-group', $form_field["field_slug"], function( $input ) use ( $form_field ) {
+            register_setting($plugin_data['slug'] . '-option-group', $form_field["field_slug"], function( $input ) use ( $form_field ) {
                 return exlog_validate( $input, $form_field );
             });
         }
@@ -14,7 +16,7 @@ function exlog_register_options_menu_settings() {
 };
 
 function exlog_create_options_menu() {
-    add_options_page( EXLOG_PLUGIN_DATA['name'] . ' Options', EXLOG_PLUGIN_DATA['name'], 'manage_options', EXLOG_PLUGIN_DATA['slug'], 'exlog_generate_options_view' );
+    add_options_page( $plugin_data['name'] . ' Options', $plugin_data['name'], 'manage_options', $plugin_data['slug'], 'exlog_generate_options_view' );
 }
 
 function exlog_generate_options_view() {
@@ -28,9 +30,9 @@ function exlog_generate_options_view() {
 add_action( 'admin_enqueue_scripts', 'exlog_enqueue_for_options' );
 
 function exlog_enqueue_for_options() {
-    wp_enqueue_style( 'exlog-styles', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . EXLOG_PLUGIN_DATA['slug'] . '/styles/style.css' );
-    wp_enqueue_script( 'exlog-validation-tools', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . EXLOG_PLUGIN_DATA['slug'] . '/js/tools.js' );
-    wp_enqueue_script( 'exlog-scripts', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . EXLOG_PLUGIN_DATA['slug'] . '/js/external_login.js' );
-    wp_enqueue_script( 'exlog-option-conditionals', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . EXLOG_PLUGIN_DATA['slug'] . '/js/options_condtionals.js' );
-    wp_enqueue_script( 'exlog-test', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . EXLOG_PLUGIN_DATA['slug'] . '/js/exlog_test.js' );
+    wp_enqueue_style( 'exlog-styles', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . $plugin_data['slug'] . '/styles/style.css' );
+    wp_enqueue_script( 'exlog-validation-tools', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . $plugin_data['slug'] . '/js/tools.js' );
+    wp_enqueue_script( 'exlog-scripts', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . $plugin_data['slug'] . '/js/external_login.js' );
+    wp_enqueue_script( 'exlog-option-conditionals', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . $plugin_data['slug'] . '/js/options_condtionals.js' );
+    wp_enqueue_script( 'exlog-test', plugin_dir_url(EXLOG_PATH_PLUGIN_BASE) . $plugin_data['slug'] . '/js/exlog_test.js' );
 }

--- a/options/options_fields.php
+++ b/options/options_fields.php
@@ -1,6 +1,6 @@
 <?php
 
-define('EXLOG_OPTION_FIELDS', array(
+$option_fields = array(
     array(
         "section_name" => "Functionality Settings",
         "section_slug" => "feature_settings",
@@ -307,4 +307,6 @@ define('EXLOG_OPTION_FIELDS', array(
             ),
         ),
     ),
-));
+);
+$option_fields_s = serialize($option_fields);
+define ( 'EXLOG_OPTION_FIELDS' , $option_fields_s );

--- a/views/options_page.php
+++ b/views/options_page.php
@@ -2,15 +2,17 @@
   class="exlog_options_page"
 >
     <?php screen_icon(); ?>
-    <h2><?php echo EXLOG_PLUGIN_DATA['name'] ?> Options</h2>
+    <h2><?php $plugin_data = unserialize(EXLOG_PLUGIN_DATA);
+	echo $plugin_data['name'] ?> Options</h2>
 
     <form method="post" action="options.php">
         <?php
-          settings_fields( EXLOG_PLUGIN_DATA['slug'] . '-option-group' );
-          do_settings_fields( EXLOG_PLUGIN_DATA['slug'] . '-option-group', '' );
+          settings_fields( $plugin_data['slug'] . '-option-group' );
+          do_settings_fields( $plugin_data['slug'] . '-option-group', '' );
         ?>
 
-        <?php foreach (EXLOG_OPTION_FIELDS as $form_section) : ?>
+        <?php $option_fields = unserialize(EXLOG_OPTION_FIELDS);
+		foreach ($option_fields as $form_section) : ?>
             <div class="options_section_container">
               <div class="options_section <?php echo $form_section['section_slug']; ?>">
                 <h3><?php echo $form_section['section_name'] ?></h3>


### PR DESCRIPTION
Somehow PHP 5.6 seems to only support serialized arrays in constant definitions. So i serialized the plugin option array and the settings array - i don't know if it's very performant to deserialize them where i did. I have no experience with wp plugins, i just kept fixing errors as they popped up 🤣 